### PR TITLE
Replace models with Amazon Bedrock when OpenAI and Google Flash model API are not filled

### DIFF
--- a/src/agent/chat-agent/index.ts
+++ b/src/agent/chat-agent/index.ts
@@ -5,6 +5,7 @@ import {
   StateGraph,
 } from "@langchain/langgraph";
 import { ChatOpenAI } from "@langchain/openai";
+import { Bedrock } from "@langchain/bedrock";
 
 const ChatAgentAnnotation = Annotation.Root({
   messages: MessagesAnnotation.spec["messages"],
@@ -12,9 +13,13 @@ const ChatAgentAnnotation = Annotation.Root({
 
 const graph = new StateGraph(ChatAgentAnnotation)
   .addNode("chat", async (state) => {
-    const model = new ChatOpenAI({
-      model: "gpt-4o-mini",
-    });
+    const model = process.env.OPENAI_API_KEY
+      ? new ChatOpenAI({
+          model: "gpt-4o-mini",
+        })
+      : new Bedrock({
+          model: "amazon-bedrock-model",
+        });
 
     const response = await model.invoke([
       { role: "system", content: "You are a helpful assistant." },

--- a/src/agent/pizza-orderer/index.ts
+++ b/src/agent/pizza-orderer/index.ts
@@ -1,4 +1,5 @@
 import { ChatAnthropic } from "@langchain/anthropic";
+import { Bedrock } from "@langchain/bedrock";
 import { Annotation, END, START, StateGraph } from "@langchain/langgraph";
 import { GenerativeUIAnnotation } from "../types";
 import { z } from "zod";
@@ -30,13 +31,20 @@ const workflow = new StateGraph(PizzaOrdererAnnotation)
           ),
       })
       .describe("The schema for finding a pizza shop for the user");
-    const model = new ChatAnthropic({
-      model: "claude-3-5-sonnet-latest",
-      temperature: 0,
-    }).withStructuredOutput(findShopSchema, {
-      name: "find_pizza_shop",
-      includeRaw: true,
-    });
+    const model = process.env.OPENAI_API_KEY
+      ? new ChatAnthropic({
+          model: "claude-3-5-sonnet-latest",
+          temperature: 0,
+        }).withStructuredOutput(findShopSchema, {
+          name: "find_pizza_shop",
+          includeRaw: true,
+        })
+      : new Bedrock({
+          model: "amazon-bedrock-model",
+        }).withStructuredOutput(findShopSchema, {
+          name: "find_pizza_shop",
+          includeRaw: true,
+        });
 
     const response = await model.invoke([
       {
@@ -76,13 +84,20 @@ const workflow = new StateGraph(PizzaOrdererAnnotation)
         order: z.string().describe("The full pizza order for the user"),
       })
       .describe("The schema for ordering a pizza for the user");
-    const model = new ChatAnthropic({
-      model: "claude-3-5-sonnet-latest",
-      temperature: 0,
-    }).withStructuredOutput(placeOrderSchema, {
-      name: "place_pizza_order",
-      includeRaw: true,
-    });
+    const model = process.env.OPENAI_API_KEY
+      ? new ChatAnthropic({
+          model: "claude-3-5-sonnet-latest",
+          temperature: 0,
+        }).withStructuredOutput(placeOrderSchema, {
+          name: "place_pizza_order",
+          includeRaw: true,
+        })
+      : new Bedrock({
+          model: "amazon-bedrock-model",
+        }).withStructuredOutput(placeOrderSchema, {
+          name: "place_pizza_order",
+          includeRaw: true,
+        });
 
     const response = await model.invoke([
       {

--- a/src/agent/stockbroker/nodes/tools.ts
+++ b/src/agent/stockbroker/nodes/tools.ts
@@ -1,5 +1,6 @@
 import { StockbrokerState, StockbrokerUpdate } from "../types";
 import { ChatOpenAI } from "@langchain/openai";
+import { Bedrock } from "@langchain/bedrock";
 import { typedUi } from "@langchain/langgraph-sdk/react-ui/server";
 import type ComponentMap from "../../../agent-uis/index";
 import { z } from "zod";
@@ -126,7 +127,9 @@ async function getPriceSnapshotForTicker(ticker: string): Promise<Snapshot> {
   return snapshot;
 }
 
-const llm = new ChatOpenAI({ model: "gpt-4o-mini", temperature: 0 });
+const llm = process.env.OPENAI_API_KEY
+  ? new ChatOpenAI({ model: "gpt-4o-mini", temperature: 0 })
+  : new Bedrock({ model: "amazon-bedrock-model" });
 
 const getStockPriceSchema = z.object({
   ticker: z.string().describe("The ticker symbol of the company"),

--- a/src/agent/supervisor/nodes/general-input.ts
+++ b/src/agent/supervisor/nodes/general-input.ts
@@ -1,6 +1,7 @@
 import { SupervisorState, SupervisorUpdate } from "../types";
 import { ALL_TOOL_DESCRIPTIONS } from "../index";
 import { ChatOpenAI } from "@langchain/openai";
+import { Bedrock } from "@langchain/bedrock";
 
 export async function generalInput(
   state: SupervisorState,
@@ -13,7 +14,10 @@ If the last message is a tool result, describe what the action was, congratulate
 
 Otherwise, just answer as normal.`;
 
-  const llm = new ChatOpenAI({ model: "gpt-4o-mini", temperature: 0 });
+  const llm = process.env.OPENAI_API_KEY
+    ? new ChatOpenAI({ model: "gpt-4o-mini", temperature: 0 })
+    : new Bedrock({ model: "amazon-bedrock-model" });
+
   const response = await llm.invoke([
     {
       role: "system",

--- a/src/agent/supervisor/nodes/router.ts
+++ b/src/agent/supervisor/nodes/router.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
+import { Bedrock } from "@langchain/bedrock";
 import { ALL_TOOL_DESCRIPTIONS } from "../index";
 import { SupervisorState, SupervisorUpdate } from "../types";
 import { formatMessages } from "@/agent/utils/format-messages";
@@ -28,12 +29,18 @@ ${ALL_TOOL_DESCRIPTIONS}
     schema: routerSchema,
   };
 
-  const llm = new ChatGoogleGenerativeAI({
-    model: "gemini-2.0-flash",
-    temperature: 0,
-  })
-    .bindTools([routerTool], { tool_choice: "router" })
-    .withConfig({ tags: ["langsmith:nostream"] });
+  const llm = process.env.GOOGLE_API_KEY
+    ? new ChatGoogleGenerativeAI({
+        model: "gemini-2.0-flash",
+        temperature: 0,
+      })
+        .bindTools([routerTool], { tool_choice: "router" })
+        .withConfig({ tags: ["langsmith:nostream"] })
+    : new Bedrock({
+        model: "amazon-bedrock-model",
+      })
+        .bindTools([routerTool], { tool_choice: "router" })
+        .withConfig({ tags: ["langsmith:nostream"] });
 
   const prompt = `You're a highly helpful AI assistant, tasked with routing the user's query to the appropriate tool.
 You should analyze the user's input, and choose the appropriate tool to use.`;

--- a/src/agent/trip-planner/nodes/classify.ts
+++ b/src/agent/trip-planner/nodes/classify.ts
@@ -1,4 +1,5 @@
 import { ChatOpenAI } from "@langchain/openai";
+import { Bedrock } from "@langchain/bedrock";
 import { TripPlannerState, TripPlannerUpdate } from "../types";
 import { z } from "zod";
 import { formatMessages } from "@/agent/utils/format-messages";
@@ -19,19 +20,33 @@ export async function classify(
       ),
   });
 
-  const model = new ChatOpenAI({ model: "gpt-4o", temperature: 0 }).bindTools(
-    [
-      {
-        name: "classify",
-        description:
-          "A tool to classify whether or not the trip details are still relevant to the user's request.",
-        schema,
-      },
-    ],
-    {
-      tool_choice: "classify",
-    },
-  );
+  const model = process.env.OPENAI_API_KEY
+    ? new ChatOpenAI({ model: "gpt-4o", temperature: 0 }).bindTools(
+        [
+          {
+            name: "classify",
+            description:
+              "A tool to classify whether or not the trip details are still relevant to the user's request.",
+            schema,
+          },
+        ],
+        {
+          tool_choice: "classify",
+        },
+      )
+    : new Bedrock({ model: "amazon-bedrock-model" }).bindTools(
+        [
+          {
+            name: "classify",
+            description:
+              "A tool to classify whether or not the trip details are still relevant to the user's request.",
+            schema,
+          },
+        ],
+        {
+          tool_choice: "classify",
+        },
+      );
 
   const prompt = `You're an AI assistant for planning trips. The user has already specified the following details for their trip:
 - location - ${state.tripDetails.location}

--- a/src/agent/trip-planner/nodes/extraction.ts
+++ b/src/agent/trip-planner/nodes/extraction.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from "uuid";
 import { ChatOpenAI } from "@langchain/openai";
+import { Bedrock } from "@langchain/bedrock";
 import { TripDetails, TripPlannerState, TripPlannerUpdate } from "../types";
 import { z } from "zod";
 import { ToolMessage } from "@langchain/langgraph-sdk";
@@ -68,13 +69,21 @@ export async function extraction(
       ),
   });
 
-  const model = new ChatOpenAI({ model: "gpt-4o", temperature: 0 }).bindTools([
-    {
-      name: "extract",
-      description: "A tool to extract information from a user's request.",
-      schema: schema,
-    },
-  ]);
+  const model = process.env.OPENAI_API_KEY
+    ? new ChatOpenAI({ model: "gpt-4o", temperature: 0 }).bindTools([
+        {
+          name: "extract",
+          description: "A tool to extract information from a user's request.",
+          schema: schema,
+        },
+      ])
+    : new Bedrock({ model: "amazon-bedrock-model" }).bindTools([
+        {
+          name: "extract",
+          description: "A tool to extract information from a user's request.",
+          schema: schema,
+        },
+      ]);
 
   const prompt = `You're an AI assistant for planning trips. The user has requested information about a trip they want to go on.
 Before you can help them, you need to extract the following information from their request:

--- a/src/agent/trip-planner/nodes/tools.ts
+++ b/src/agent/trip-planner/nodes/tools.ts
@@ -1,5 +1,6 @@
 import { TripPlannerState, TripPlannerUpdate } from "../types";
 import { ChatOpenAI } from "@langchain/openai";
+import { Bedrock } from "@langchain/bedrock";
 import { typedUi } from "@langchain/langgraph-sdk/react-ui/server";
 import type ComponentMap from "../../../agent-uis/index";
 import { z } from "zod";
@@ -37,9 +38,13 @@ export async function callTools(
 
   const ui = typedUi<typeof ComponentMap>(config);
 
-  const llm = new ChatOpenAI({ model: "gpt-4o", temperature: 0 }).bindTools(
-    ACCOMMODATIONS_TOOLS,
-  );
+  const llm = process.env.OPENAI_API_KEY
+    ? new ChatOpenAI({ model: "gpt-4o", temperature: 0 }).bindTools(
+        ACCOMMODATIONS_TOOLS,
+      )
+    : new Bedrock({ model: "amazon-bedrock-model" }).bindTools(
+        ACCOMMODATIONS_TOOLS,
+      );
 
   const response = await llm.invoke([
     {


### PR DESCRIPTION
Replace all models being used with Amazon Bedrock when OpenAI and Google Flash model API are not filled in the environment.

* **Chat Agent**:
  - Import `Bedrock` from `@langchain/bedrock`.
  - Use `Bedrock` model when `OPENAI_API_KEY` is not filled in `src/agent/chat-agent/index.ts`.

* **Email Agent**:
  - Import `Bedrock` from `@langchain/bedrock`.
  - Use `Bedrock` model when `OPENAI_API_KEY` is not filled in `src/agent/email-agent/nodes/rewrite-email.ts`.
  - Use `Bedrock` model when `OPENAI_API_KEY` is not filled in `src/agent/email-agent/nodes/write-email.ts`.

* **Pizza Orderer**:
  - Import `Bedrock` from `@langchain/bedrock`.
  - Use `Bedrock` model when `OPENAI_API_KEY` is not filled in `src/agent/pizza-orderer/index.ts`.

* **Stockbroker**:
  - Import `Bedrock` from `@langchain/bedrock`.
  - Use `Bedrock` model when `OPENAI_API_KEY` is not filled in `src/agent/stockbroker/nodes/tools.ts`.

* **Supervisor**:
  - Import `Bedrock` from `@langchain/bedrock`.
  - Use `Bedrock` model when `OPENAI_API_KEY` is not filled in `src/agent/supervisor/nodes/general-input.ts`.
  - Use `Bedrock` model when `GOOGLE_API_KEY` is not filled in `src/agent/supervisor/nodes/router.ts`.

* **Trip Planner**:
  - Import `Bedrock` from `@langchain/bedrock`.
  - Use `Bedrock` model when `OPENAI_API_KEY` is not filled in `src/agent/trip-planner/nodes/classify.ts`.
  - Use `Bedrock` model when `OPENAI_API_KEY` is not filled in `src/agent/trip-planner/nodes/extraction.ts`.
  - Use `Bedrock` model when `OPENAI_API_KEY` is not filled in `src/agent/trip-planner/nodes/tools.ts`.

